### PR TITLE
Add gvfs access

### DIFF
--- a/re.sonny.Workbench.json
+++ b/re.sonny.Workbench.json
@@ -19,7 +19,8 @@
     "--socket=wayland",
     "--device=dri",
     "--share=network",
-    "--socket=pulseaudio"
+    "--socket=pulseaudio",
+    "--talk-name=org.gtk.vfs.*"
   ],
   "cleanup": [
     "/include",


### PR DESCRIPTION
Without this opening the file chooser, I get:

```
GVFS-cannot open directory /usr/share/gvfs/remote-volume-monitors: Error opening directory “/usr/share/gvfs/remote-volume-monitors”: No such file or directory
```